### PR TITLE
登録画面の追加

### DIFF
--- a/services/web/app/components/AuthenticatedLayout.tsx
+++ b/services/web/app/components/AuthenticatedLayout.tsx
@@ -18,6 +18,7 @@ export default function AuthenticatedLayout({ children }: { children: React.Reac
           <div className="flex items-center space-x-4">
             <Link href="/" className="hover:underline">ホーム</Link>
             <Link href="/portfolio" className="hover:underline">ポートフォリオ</Link>
+            <Link href="/stock-registration" className="hover:underline">持ち株の登録</Link>
             <Link href="/transactions" className="hover:underline">取引履歴</Link>
             <Link href="/analysis" className="hover:underline">分析</Link>
             <button 

--- a/services/web/app/stock-registration/page.tsx
+++ b/services/web/app/stock-registration/page.tsx
@@ -1,0 +1,28 @@
+export default function StockRegistrationPage() {
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <h1 className="text-3xl font-bold mb-6">持ち株の登録</h1>
+      <div className="bg-white p-6 rounded-lg shadow-md">
+        <form>
+          <div className="mb-4">
+            <label htmlFor="stock-code" className="block text-gray-700 font-bold mb-2">銘柄コード</label>
+            <input type="text" id="stock-code" name="stock-code" className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" />
+          </div>
+          <div className="mb-4">
+            <label htmlFor="quantity" className="block text-gray-700 font-bold mb-2">株数</label>
+            <input type="number" id="quantity" name="quantity" className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" />
+          </div>
+          <div className="mb-4">
+            <label htmlFor="acquisition-price" className="block text-gray-700 font-bold mb-2">取得単価</label>
+            <input type="number" id="acquisition-price" name="acquisition-price" className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" />
+          </div>
+          <div className="flex items-center justify-between">
+            <button type="submit" className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline">
+              登録
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## 概要
「持ち株管理」のリンクを作成しました。

## 変更内容
- 「持ち株管理」カードを新設

## 動作確認方法
- トップページを表示し、「持ち株管理」カードのリンクから持ち株登録ページへ遷移できること

## 関連チケット
- Issue番号: 

## 備考
- 戻るボタン未実装

## チェックリスト | Checklist

- [x] コードの整合性を確認しました
- [x] 必要なテストケースを追加しました（UI表示確認）
- [ ] ドキュメントを更新しました
